### PR TITLE
Implement agentctl CLI and share backend modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,31 @@ cargo run --manifest-path backend/Cargo.toml
 
 서버는 기본적으로 `http://localhost:8080`에서 실행됩니다.
 
-### 2. 프런트엔드 실행
+### 2. CLI (`agentctl`) 활용
+
+디자인 문서에서 제시한 CLI 플로우를 그대로 사용할 수 있도록 `agentctl` 바이너리를 제공합니다. 백엔드와 동일한 SQLite DB와 파일 시스템을 공유하므로 GUI 없이도 동기화 작업을 수행할 수 있습니다.
+
+```bash
+# 설치된 도구 재검색
+cargo run --manifest-path backend/Cargo.toml --bin agentctl -- scan
+
+# 도구 상태 요약
+cargo run --manifest-path backend/Cargo.toml --bin agentctl -- list
+
+# 추천 MCP 서버 조회
+cargo run --manifest-path backend/Cargo.toml --bin agentctl -- rules list
+
+# 추천 서버 적용 + 에이전트 동기화
+cargo run --manifest-path backend/Cargo.toml --bin agentctl -- apply --rule anthropic --agent claude
+
+# 마스터 구성으로 전체 동기화
+cargo run --manifest-path backend/Cargo.toml --bin agentctl -- sync
+
+# 특정 서버 활성/비활성 토글
+cargo run --manifest-path backend/Cargo.toml --bin agentctl -- feature toggle --agent claude --key anthropic --on
+```
+
+### 3. 프런트엔드 실행
 
 ```bash
 cd frontend

--- a/ai-agent-management-design.md
+++ b/ai-agent-management-design.md
@@ -1,0 +1,207 @@
+# AI Agent 통합 관리 시스템 설계 문서
+
+## 목차
+1. [개요](#1-개요)  
+2. [핵심 기능](#2-핵심-기능)  
+   - [에이전트 탐색 & 등록](#21-에이전트-탐색--등록)  
+   - [MCP 동기화](#22-mcp-동기화)  
+   - [특화 기능 관리](#23-특화-기능-관리)  
+   - [추천 & 검색](#24-추천--검색)  
+   - [업데이트 대응](#25-업데이트-대응)  
+3. [기술 스택](#3-기술-스택)  
+4. [데이터 모델](#4-데이터-모델)  
+5. [MCP 규칙 포맷 (YAML 예시)](#5-mcp-규칙-포맷-yaml-예시)  
+6. [Tauri 커맨드 예시](#6-tauri-커맨드-예시)  
+7. [CLI 예시](#7-cli-예시)  
+8. [업데이트 & 변경 감지 전략](#8-업데이트--변경-감지-전략)  
+9. [배포 전략](#9-배포-전략)  
+10. [로드맵](#10-로드맵)  
+
+---
+
+## 1. 개요
+로컬에 설치된 **AI Agent (CLI, IDE 플러그인, 데스크탑 앱)** 들을 하나의 시스템에서 관리하기 위한 MCP 기반 동기화 툴을 설계한다.  
+
+- **목표**:  
+  - 설치된 에이전트 자동 탐색  
+  - MCP 규칙(rule) 관리 및 동기화  
+  - 에이전트별 특화 기능(커맨드, 서브에이전트) 관리  
+  - 업데이트 시 자동 변경 감지 및 동기화 유지  
+  - 웹/데스크탑(Tauri) 크로스플랫폼 배포  
+
+---
+
+## 2. 핵심 기능
+
+### 2.1 에이전트 탐색 & 등록
+- 설치된 에이전트 자동 탐색  
+- 확인 항목:
+  - 설치 여부  
+  - 버전  
+  - 활성화 여부  
+  - 언어/로케일 설정  
+  - 특화 기능(예: Claude Code → commands, sub-agents)
+
+### 2.2 MCP 동기화
+- "내 MCP 목록" ↔ "에이전트 MCP 목록" 비교  
+- 기능:
+  - 추가 / 삭제 / 수정  
+  - 일괄 동기화  
+  - 충돌 해결  
+
+### 2.3 특화 기능 관리
+- 에이전트별 제공 기능 탐색 및 관리  
+  - 명령어(commands)  
+  - 서브에이전트(sub-agents)  
+  - 기능별 활성화 여부  
+
+### 2.4 추천 & 검색
+- 로컬 사용 빈도 기반 인기 규칙 추천  
+- 온라인 카탈로그 기반 추천 가능  
+- 태그/키워드 기반 검색 기능  
+
+### 2.5 업데이트 대응
+- 에이전트 업데이트 시 MCP 변경(추가/삭제/수정) 감지  
+- 변경 사항을 DB 및 GUI에 반영  
+- 필요 시 사용자 알림 및 재동기화  
+
+---
+
+## 3. 기술 스택
+
+- **프론트엔드**: React + TypeScript (웹/데스크탑 공용)  
+- **데스크탑 프레임워크**: Tauri (Rust + WebView)  
+- **로컬 백엔드**: Rust 모듈 (에이전트 스캐너, MCP 동기화 엔진)  
+- **데이터 저장소**: SQLite + YAML (규칙 저장)  
+- **CLI 툴**: `agentctl` (Rust 기반, GUI와 DB 공유)  
+
+---
+
+## 4. 데이터 모델
+
+### agents
+```sql
+CREATE TABLE agents (
+  id TEXT PRIMARY KEY,
+  name TEXT,
+  kind TEXT CHECK(kind IN ('cli','desktop','ide')),
+  version TEXT,
+  installed INTEGER NOT NULL,
+  active INTEGER NOT NULL,
+  language TEXT,
+  path TEXT,
+  meta JSON
+);
+```
+
+### agent_features
+```sql
+CREATE TABLE agent_features (
+  agent_id TEXT,
+  type TEXT,
+  key TEXT,
+  enabled INTEGER NOT NULL,
+  meta JSON,
+  PRIMARY KEY(agent_id, type, key)
+);
+```
+
+### mcp_rules
+```sql
+CREATE TABLE mcp_rules (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  tags TEXT,
+  spec JSON,
+  popular_score REAL DEFAULT 0,
+  updated_at TEXT
+);
+```
+
+### agent_mcp
+```sql
+CREATE TABLE agent_mcp (
+  agent_id TEXT,
+  rule_id TEXT,
+  status TEXT CHECK(status IN ('applied','pending','removed')),
+  meta JSON,
+  PRIMARY KEY(agent_id, rule_id)
+);
+```
+
+---
+
+## 5. MCP 규칙 포맷 (YAML 예시)
+```yaml
+id: auto_format
+title: Auto Formatter
+tags: [lint, format, ide]
+applies_to:
+  - type: ide
+    products: [vscode, jetbrains]
+spec:
+  actions:
+    - hook: on_save
+      run: ["prettier", "--write", "{file}"]
+version: 2
+```
+
+---
+
+## 6. Tauri 커맨드 예시
+```rust
+#[tauri::command]
+pub async fn scan_agents() -> Result<Vec<Agent>, String> { ... }
+
+#[tauri::command]
+pub async fn list_mcp_rules(q: Option<String>) -> Result<Vec<serde_json::Value>, String> { ... }
+
+#[tauri::command]
+pub async fn apply_mcp_rules(payload: ApplyPayload) -> Result<(), String> { ... }
+
+#[tauri::command]
+pub async fn toggle_feature(agent_id:String, feature_type:String, key:String, enabled:bool) -> Result<(), String> { ... }
+```
+
+---
+
+## 7. CLI 예시
+```bash
+agentctl scan
+agentctl list
+agentctl rules list --tag ide --q "format"
+agentctl apply --agent claude_code --rule auto_format
+agentctl feature toggle --agent claude_code --type command --key explain_code --on
+```
+
+---
+
+## 8. 업데이트 & 변경 감지 전략
+1. 에이전트 업데이트 주기적으로 스캔  
+   - CLI → `--version` 체크  
+   - IDE → `package.json`/manifest 비교  
+   - 데스크탑 → 버전/설정 파일 비교  
+
+2. MCP 규칙 변화 감지  
+   - 추가: 새로운 커맨드/서브에이전트 발견  
+   - 삭제: 이전 존재하던 기능 제거됨  
+   - 수정: 기존 규칙 스펙 변경  
+
+3. 변경 발생 시 처리  
+   - 사용자 알림 (GUI/CLI)  
+   - DB 업데이트  
+   - 자동 재동기화 옵션 제공  
+
+---
+
+## 9. 배포 전략
+- **웹**: 제한적 (규칙 관리, 내보내기)  
+- **데스크탑**: 풀 기능 (macOS, Windows, Tauri)  
+- **업데이트**: Tauri Auto Updater + 코드사인  
+
+---
+
+## 10. 로드맵
+1. **MVP**: CLI 스캐너 + MCP 카탈로그 + 수동 동기화  
+2. **Beta**: macOS/Windows 네이티브 스캐너, 롤백 기능, 추천 점수  
+3. **1.0**: IDE 플러그인 지원 확대, 자동 동기화 스케줄러, 프리셋 공유  

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -54,6 +54,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,8 +191,10 @@ dependencies = [
 name = "backend"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "chrono",
+ "clap",
  "parking_lot",
  "rusqlite",
  "serde",
@@ -161,7 +219,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -215,8 +273,54 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -385,6 +489,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,7 +820,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1209,6 +1331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,7 +1446,7 @@ checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.2.0",
  "windows-result",
  "windows-strings",
 ]
@@ -1347,6 +1475,12 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
@@ -1357,7 +1491,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1366,7 +1500,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1375,7 +1509,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1384,7 +1518,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1393,7 +1536,7 @@ version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1402,14 +1545,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1419,10 +1579,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1431,10 +1603,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1443,10 +1627,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1455,10 +1651,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "zerocopy"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,3 +16,5 @@ rusqlite = { version = "0.30", features = ["bundled", "chrono"] }
 chrono = { version = "0.4", features = ["serde"] }
 walkdir = "2"
 parking_lot = "0.12"
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"

--- a/backend/src/bin/agentctl.rs
+++ b/backend/src/bin/agentctl.rs
@@ -1,0 +1,477 @@
+use std::fs;
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use backend::config::{
+    MasterConfigResponse, McpSettings, RecommendedServer, SyncStatus, SyncSummary,
+    ToolConfiguration,
+};
+use backend::db::Database;
+use backend::sync;
+use chrono::Utc;
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+
+#[derive(Parser)]
+#[command(name = "agentctl", about = "AI MCP 동기화 CLI", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// 로컬에 설치된 도구를 다시 검색합니다.
+    Scan,
+    /// 데이터베이스에 기록된 도구와 마스터 구성 상태를 출력합니다.
+    List,
+    /// 마스터 MCP 구성을 확인하거나 갱신합니다.
+    #[command(subcommand)]
+    Master(MasterCommand),
+    /// 추천 MCP 서버(룰) 목록을 조회합니다.
+    #[command(subcommand)]
+    Rules(RulesCommand),
+    /// 추천 MCP 서버를 마스터 구성에 적용하고 지정한 에이전트에 동기화합니다.
+    Apply(ApplyArgs),
+    /// 마스터 구성으로 도구를 동기화합니다.
+    Sync(SyncArgs),
+    /// 최근 동기화 기록을 확인합니다.
+    History(HistoryArgs),
+    /// 에이전트별 기능(현재는 MCP 서버 활성화) 토글
+    #[command(subcommand)]
+    Feature(FeatureCommand),
+}
+
+#[derive(Subcommand)]
+enum MasterCommand {
+    /// 현재 마스터 MCP 구성을 출력합니다.
+    Show,
+    /// JSON 파일에서 마스터 MCP 구성을 갱신합니다.
+    Set(MasterSetArgs),
+}
+
+#[derive(Args)]
+struct MasterSetArgs {
+    /// JSON 파일 경로 ("-" 입력 시 STDIN 사용)
+    #[arg(value_name = "PATH")]
+    path: PathBuf,
+}
+
+#[derive(Subcommand)]
+enum RulesCommand {
+    /// 추천 MCP 서버 목록을 표 형태로 출력합니다.
+    List,
+}
+
+#[derive(Args)]
+struct ApplyArgs {
+    /// 룰/서버 ID
+    #[arg(long, value_name = "RULE_ID")]
+    rule: String,
+    /// 적용할 에이전트(도구) 이름
+    #[arg(long, value_name = "AGENT")]
+    agent: String,
+    /// 마스터 구성에 추가할 때 사용할 enabled 값
+    #[arg(long)]
+    enabled: Option<bool>,
+}
+
+#[derive(Args)]
+struct SyncArgs {
+    /// 특정 도구만 동기화하려면 지정합니다.
+    #[arg(long, value_name = "AGENT")]
+    agent: Option<String>,
+}
+
+#[derive(Args)]
+struct HistoryArgs {
+    /// 출력할 기록 개수 (기본: 10)
+    #[arg(long, default_value_t = 10)]
+    limit: usize,
+}
+
+#[derive(Subcommand)]
+enum FeatureCommand {
+    /// MCP 서버의 활성화 여부를 토글합니다.
+    Toggle(FeatureToggleArgs),
+}
+
+#[derive(Clone, ValueEnum)]
+enum FeatureType {
+    /// MCP 서버 활성화 토글
+    Server,
+}
+
+#[derive(Args)]
+struct FeatureToggleArgs {
+    /// 에이전트 이름
+    #[arg(long, value_name = "AGENT")]
+    agent: String,
+    /// 기능 유형 (현재 server만 지원)
+    #[arg(long, value_enum, default_value = "server")]
+    feature_type: FeatureType,
+    /// 서버 ID
+    #[arg(long, value_name = "KEY")]
+    key: String,
+    /// 활성화
+    #[arg(long, action = ArgAction::SetTrue)]
+    on: bool,
+    /// 비활성화
+    #[arg(long, action = ArgAction::SetTrue)]
+    off: bool,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let db = Database::initialize()?;
+
+    match cli.command {
+        Command::Scan => handle_scan(&db),
+        Command::List => handle_list(&db),
+        Command::Master(cmd) => handle_master(&db, cmd),
+        Command::Rules(cmd) => handle_rules(&db, cmd),
+        Command::Apply(args) => handle_apply(&db, args),
+        Command::Sync(args) => handle_sync(&db, args),
+        Command::History(args) => handle_history(&db, args),
+        Command::Feature(cmd) => handle_feature(&db, cmd),
+    }
+}
+
+fn handle_scan(db: &Database) -> Result<()> {
+    let discovered = sync::discover_tools(db)?;
+    println!("{}개의 도구 구성을 검색했습니다.", discovered.len());
+    for tool in discovered {
+        println!("- {} ({})", tool.name, tool.config_path);
+    }
+    Ok(())
+}
+
+fn handle_list(db: &Database) -> Result<()> {
+    let master = db.ensure_master_config()?;
+    let tools = load_tool_configs(db)?;
+
+    if tools.is_empty() {
+        println!("등록된 도구가 없습니다. 먼저 'agentctl scan'을 실행하세요.");
+        return Ok(());
+    }
+
+    println!("마스터 구성 최신화: {}", master.updated_at.to_rfc3339());
+    println!("\n도구 목록:");
+    for tool in tools {
+        println!("\n■ {}", tool.name);
+        println!("  경로: {}", tool.config_path);
+        if tool.settings == master.settings {
+            println!("  상태: ✅ 마스터와 동기화됨");
+        } else {
+            let diff = describe_diff(&master.settings, &tool.settings);
+            println!("  상태: ⚠️ 동기화 필요");
+            if let Some(diff) = diff {
+                println!("    차이: {}", diff);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn handle_master(db: &Database, cmd: MasterCommand) -> Result<()> {
+    match cmd {
+        MasterCommand::Show => {
+            let config = db.ensure_master_config()?;
+            let rendered = serde_json::to_string_pretty(&config.settings)?;
+            println!("{}", rendered);
+            Ok(())
+        }
+        MasterCommand::Set(args) => {
+            let content = read_from_path_or_stdin(&args.path)?;
+            let parsed: McpSettings = serde_json::from_str(&content)
+                .context("JSON 형식의 MCP 설정을 읽는 데 실패했습니다")?;
+            db.upsert_master_config(&parsed)?;
+            let updated = db.ensure_master_config()?;
+            println!(
+                "마스터 구성을 갱신했습니다. ({} 서버)",
+                updated.settings.servers.len()
+            );
+            Ok(())
+        }
+    }
+}
+
+fn handle_rules(db: &Database, cmd: RulesCommand) -> Result<()> {
+    match cmd {
+        RulesCommand::List => {
+            let rules = db.list_recommended_servers()?;
+            if rules.is_empty() {
+                println!("추천 MCP 서버가 없습니다.");
+            } else {
+                println!("추천 MCP 서버 목록:");
+                for rule in rules {
+                    print_recommended(&rule);
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn handle_apply(db: &Database, args: ApplyArgs) -> Result<()> {
+    let server = db
+        .get_recommended_server(&args.rule)?
+        .ok_or_else(|| anyhow!("추천 서버 '{}'를 찾을 수 없습니다.", args.rule))?;
+
+    let mut master = db.ensure_master_config()?.settings;
+    let enabled = args.enabled.unwrap_or(server.default_enabled);
+    upsert_server_into_master(&mut master, &server, enabled);
+    db.upsert_master_config(&master)?;
+    println!("'{}' 서버를 마스터 구성에 적용했습니다.", server.name);
+
+    let refreshed = db.ensure_master_config()?;
+    let summary = sync_tool_for_agent(db, &args.agent, &refreshed)?;
+    print_sync_summary(&summary, true);
+    Ok(())
+}
+
+fn handle_sync(db: &Database, args: SyncArgs) -> Result<()> {
+    let master = db.ensure_master_config()?;
+    let mut summaries = Vec::new();
+
+    let entries = match args.agent {
+        Some(ref agent) => db
+            .list_tools()?
+            .into_iter()
+            .filter(|(name, _)| name == agent)
+            .collect::<Vec<_>>(),
+        None => db.list_tools()?,
+    };
+
+    if entries.is_empty() {
+        if let Some(agent) = args.agent {
+            println!("'{}' 이름의 도구가 없습니다.", agent);
+        } else {
+            println!("동기화할 도구가 없습니다. 먼저 'agentctl scan'을 실행하세요.");
+        }
+        return Ok(());
+    }
+
+    for (name, path) in entries {
+        let settings = sync::read_settings_from_file(&path)?;
+        let config = ToolConfiguration::new(name.clone(), path.to_string_lossy(), settings);
+        let summary = sync::sync_tool(&config, &master.settings, db)?;
+        summaries.push(summary);
+    }
+
+    for summary in summaries {
+        print_sync_summary(&summary, false);
+    }
+
+    Ok(())
+}
+
+fn handle_history(db: &Database, args: HistoryArgs) -> Result<()> {
+    let history = db.recent_sync_history(args.limit)?;
+    if history.is_empty() {
+        println!("동기화 기록이 없습니다.");
+    } else {
+        println!("최근 동기화 기록:");
+        for item in history {
+            println!(
+                "- [{}] {} :: {}",
+                item.synced_at.to_rfc3339(),
+                item.tool,
+                format_status(&item)
+            );
+        }
+    }
+    Ok(())
+}
+
+fn handle_feature(db: &Database, cmd: FeatureCommand) -> Result<()> {
+    match cmd {
+        FeatureCommand::Toggle(args) => handle_feature_toggle(db, args),
+    }
+}
+
+fn handle_feature_toggle(db: &Database, args: FeatureToggleArgs) -> Result<()> {
+    if !matches!(args.feature_type, FeatureType::Server) {
+        return Err(anyhow!("현재는 server 유형만 지원합니다."));
+    }
+
+    let desired = match (args.on, args.off) {
+        (true, false) => true,
+        (false, true) => false,
+        (true, true) => {
+            return Err(anyhow!("--on 과 --off 를 동시에 사용할 수 없습니다."));
+        }
+        (false, false) => {
+            return Err(anyhow!("--on 또는 --off 중 하나를 지정하세요."));
+        }
+    };
+
+    let mut master = db.ensure_master_config()?.settings;
+    let server = master
+        .servers
+        .iter_mut()
+        .find(|item| item.id == args.key)
+        .ok_or_else(|| anyhow!("마스터 구성에서 '{}' 서버를 찾을 수 없습니다.", args.key))?;
+    server.enabled = desired;
+    db.upsert_master_config(&master)?;
+
+    println!(
+        "'{}' 서버를 {}했습니다.",
+        args.key,
+        if desired { "활성화" } else { "비활성화" }
+    );
+
+    let refreshed = db.ensure_master_config()?;
+    let summary = sync_tool_for_agent(db, &args.agent, &refreshed)?;
+    print_sync_summary(&summary, true);
+    Ok(())
+}
+
+fn load_tool_configs(db: &Database) -> Result<Vec<ToolConfiguration>> {
+    let mut tools = Vec::new();
+    for (name, path) in db.list_tools()? {
+        let settings = match sync::read_settings_from_file(&path) {
+            Ok(settings) => settings,
+            Err(err) => {
+                eprintln!("⚠️  {} 의 설정을 불러오는 데 실패했습니다: {}", name, err);
+                continue;
+            }
+        };
+        tools.push(ToolConfiguration::new(
+            name.clone(),
+            path.to_string_lossy(),
+            settings,
+        ));
+    }
+    Ok(tools)
+}
+
+fn read_from_path_or_stdin(path: &PathBuf) -> Result<String> {
+    if path.as_os_str() == "-" {
+        let mut buffer = String::new();
+        io::stdin()
+            .read_to_string(&mut buffer)
+            .context("STDIN 입력을 읽는데 실패했습니다")?;
+        Ok(buffer)
+    } else {
+        fs::read_to_string(path)
+            .with_context(|| format!("{} 파일을 읽을 수 없습니다", path.display()))
+    }
+}
+
+fn print_recommended(rule: &RecommendedServer) {
+    println!("\n- {} ({})", rule.name, rule.id);
+    if let Some(desc) = &rule.description {
+        println!("  설명: {}", desc);
+    }
+    println!("  엔드포인트: {}", rule.endpoint);
+    if let Some(category) = &rule.category {
+        println!("  카테고리: {}", category);
+    }
+    if let Some(homepage) = &rule.homepage {
+        println!("  문서: {}", homepage);
+    }
+    println!(
+        "  기본 상태: {} / API 키: {}",
+        if rule.default_enabled {
+            "활성화"
+        } else {
+            "비활성화"
+        },
+        if rule.api_key_required {
+            "필요"
+        } else {
+            "불필요"
+        }
+    );
+}
+
+fn upsert_server_into_master(master: &mut McpSettings, server: &RecommendedServer, enabled: bool) {
+    if let Some(existing) = master.servers.iter_mut().find(|item| item.id == server.id) {
+        let existing_api_key = existing.api_key.clone();
+        *existing = server.to_mcp_server(enabled);
+        if let Some(api_key) = existing_api_key {
+            existing.api_key = Some(api_key);
+        }
+    } else {
+        master.servers.push(server.to_mcp_server(enabled));
+    }
+}
+
+fn sync_tool_for_agent(
+    db: &Database,
+    agent: &str,
+    master: &MasterConfigResponse,
+) -> Result<SyncSummary> {
+    let (name, path) = db
+        .list_tools()?
+        .into_iter()
+        .find(|(name, _)| name == agent)
+        .ok_or_else(|| anyhow!("'{}' 이름의 도구를 찾을 수 없습니다.", agent))?;
+
+    let settings = sync::read_settings_from_file(&path)?;
+    let config = ToolConfiguration::new(name.clone(), path.to_string_lossy(), settings);
+    let summary = sync::sync_tool(&config, &master.settings, db)?;
+    Ok(summary)
+}
+
+fn describe_diff(master: &McpSettings, tool: &McpSettings) -> Option<String> {
+    if master == tool {
+        return None;
+    }
+    let master_ids: Vec<_> = master.servers.iter().map(|s| s.id.clone()).collect();
+    let tool_ids: Vec<_> = tool.servers.iter().map(|s| s.id.clone()).collect();
+
+    let missing: Vec<_> = master_ids
+        .iter()
+        .filter(|id| !tool_ids.contains(id))
+        .cloned()
+        .collect();
+    let extra: Vec<_> = tool_ids
+        .iter()
+        .filter(|id| !master_ids.contains(id))
+        .cloned()
+        .collect();
+
+    let mut parts = Vec::new();
+    if !missing.is_empty() {
+        parts.push(format!("{} 추가 필요", missing.join(", ")));
+    }
+    if !extra.is_empty() {
+        parts.push(format!("{} 제거 확인", extra.join(", ")));
+    }
+
+    if parts.is_empty() {
+        Some("서버 구성 차이 존재".to_string())
+    } else {
+        Some(parts.join(" / "))
+    }
+}
+
+fn print_sync_summary(summary: &SyncSummary, include_timestamp: bool) {
+    let status = match summary.status {
+        SyncStatus::Updated => "업데이트",
+        SyncStatus::Skipped => "동일",
+        SyncStatus::Failed => "실패",
+    };
+    if include_timestamp {
+        println!(
+            "[{}] {} :: {}",
+            summary.synced_at.with_timezone(&Utc).to_rfc3339(),
+            summary.tool,
+            summary.message
+        );
+    } else {
+        println!("{} :: {}", summary.tool, summary.message);
+    }
+    println!("  상태: {}", status);
+}
+
+fn format_status(summary: &SyncSummary) -> String {
+    let label = match summary.status {
+        SyncStatus::Updated => "업데이트",
+        SyncStatus::Skipped => "동일",
+        SyncStatus::Failed => "실패",
+    };
+    format!("{} - {}", label, summary.message)
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod api;
+pub mod config;
+pub mod db;
+pub mod error;
+pub mod sync;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,20 +1,14 @@
-mod api;
-mod config;
-mod db;
-mod error;
-mod sync;
-
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use api::{router, AppState};
 use axum::Router;
+use backend::api::{router, AppState};
+use backend::db::Database;
+use backend::error::BackendError;
+use backend::sync;
 use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
-
-use crate::db::Database;
-use crate::error::BackendError;
 
 #[tokio::main]
 async fn main() -> Result<(), BackendError> {


### PR DESCRIPTION
## Summary
- expose the backend modules through a library entry point so multiple binaries can share them
- add the `agentctl` CLI that scans tools, manages master MCP config, imports recommended servers, syncs agents, and toggles server activation per agent
- document how to run the new CLI alongside the existing backend/frontend instructions

## Testing
- cargo check
- cargo run --manifest-path backend/Cargo.toml --bin agentctl -- scan

------
https://chatgpt.com/codex/tasks/task_e_68ce0cee3f488321943c10d5d86e10e9