### PR TITLE
Refactor shared config logic and simplify UI actions

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -87,15 +87,7 @@ async fn import_recommended_server(
 
     let mut master = state.db.ensure_master_config()?.settings;
     let enabled = payload.enabled.unwrap_or(server.default_enabled);
-    if let Some(existing) = master.servers.iter_mut().find(|item| item.id == server.id) {
-        let existing_api_key = existing.api_key.clone();
-        *existing = server.to_mcp_server(enabled);
-        if existing_api_key.is_some() {
-            existing.api_key = existing_api_key;
-        }
-    } else {
-        master.servers.push(server.to_mcp_server(enabled));
-    }
+    master.apply_recommended_server(&server, enabled);
 
     state.db.upsert_master_config(&master)?;
     let updated = state.db.ensure_master_config()?;

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -35,6 +35,18 @@ pub struct McpSettings {
     pub project_overrides: Vec<ProjectOverride>,
 }
 
+impl McpSettings {
+    pub fn apply_recommended_server(&mut self, server: &RecommendedServer, enabled: bool) {
+        if let Some(existing) = self.servers.iter_mut().find(|item| item.id == server.id) {
+            let existing_api_key = existing.api_key.clone();
+            *existing = server.to_mcp_server(enabled);
+            existing.api_key = existing_api_key;
+        } else {
+            self.servers.push(server.to_mcp_server(enabled));
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RecommendedServer {
     pub id: String,


### PR DESCRIPTION
## Summary
- add `McpSettings::apply_recommended_server` and reuse it in the API and CLI to remove duplicated recommendation merge logic
- clean up the CLI by centralizing tool configuration loading, simplifying sync handling, and sharing sync status rendering helpers
- streamline frontend actions with a reusable `runTask` helper that manages loading and feedback states while keeping post-action updates intact, and refine backend merge logic for tool/project overrides

## Testing
- cargo test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce4cb550e88321863756a3327b34a8